### PR TITLE
Update backtrader.py

### DIFF
--- a/btconfig/parts/backtrader.py
+++ b/btconfig/parts/backtrader.py
@@ -55,3 +55,12 @@ class PartBacktrader(btconfig.BTConfigPart):
         ccerebro.addanalyzer(bt.analyzers.TradeAnalyzer, _name='TradeAnalyzer')
         ccerebro.addanalyzer(bt.analyzers.SQN, _name='SQN')
         ccerebro.addanalyzer(TradeList, _name='TradeList')
+        
+        # Add Custom Analyzers
+        all_classes = get_classes(self._instance.PATH_ANALYZER)
+        for analyzer_name, params in analyzercfg.items():
+            if analyzer_name not in ['sharpe_ratio', 'time_return', 'DrawDown', 'TradeAnalyzer', 'TradeList']:
+                if analyzer_name not in all_classes:
+                    raise Exception(f'Analyzer {analyzer_name} not found configured PATH_ANALYZER directory paths')
+                params = dict({'_name': analyzer_name}, **params)
+                ccerebro.addanalyzer(all_classes[analyzer_name], **params)


### PR DESCRIPTION
Added enhancement to Add Custom Analyzers in bt_config.json file.
Example:

import btconfig

# Custom Analyzers in exchange.trade.analyzers
btconfig.PATH_ANALYZER.append('exchange.trade.analyzers')
res = btconfig.run(btconfig.MODE_BACKTEST, r"c:\users\green\Google Drive\Coding Projects\Python\PyCharm\CryptoBot\user_config\bt_config.json")

"""
bt_config.json contains section with your Custom Analyzer Class Names and Parameters

"analyzers": {
    "MyAnalyzerClassName": {
        "param1": 1,
        "_name": "MyAnalyzerClassName"
    }
}
"""